### PR TITLE
remove r-base version selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About r-permute
 
 Home: https://github.com/gavinsimpson/permute
 
-Package license: GPL (2)
+Package license: GPL 2
 
 Feedstock license: BSD 3-Clause
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,24 +37,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
 
 about:
   home: https://github.com/gavinsimpson/permute
-  license: GPL (2)
+  license: GPL 2
   summary: 'Restricted permutations with R'
   description: |
     A set of restricted permutation designs for freely exchangeable, line transects (time series), and spatial

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win32]
   script: R CMD INSTALL --build .
   rpaths:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,9 @@ build:
 
 requirements:
   build:
-    - r-base >=2.14.0
+    - r-base
   run:
-    - r-base >=2.14.0
+    - r-base
 
 test:
   commands:


### PR DESCRIPTION

the presence of the version selectors on the r-base package prevents conda from generating pinned packages.

https://anaconda.org/conda-forge/r-permute/files